### PR TITLE
Explicitly list the supported Unicode properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -124,7 +124,86 @@ contributors: Mathias Bynens
     1. Let _property_ be that unaliased property name of _p_.
     1. Return _property_.
   </emu-alg>
-  <p>Implementations must support the following Unicode properties and their property aliases: `General_Category`, `Script`, `Script_Extensions`, and all the available binary properties (including but not limited to `Alphabetic`, `Uppercase`, `Lowercase`, `White_Space`, `Noncharacter_Code_Point`, `Default_Ignorable_Code_Point`, `Any`, `ASCII`, `Assigned`, `ID_Start`, `ID_Continue`, `Other_ID_Start`, `Other_ID_Continue`, `Join_Control`, `Emoji`, `Emoji_Presentation`, `Emoji_Modifier`, `Emoji_Modifier_Base`, etc.). This is a superset of what <a href="http://unicode.org/reports/tr18/#RL1.2">UTS18 RL1.2</a> requires. To ensure interoperability, implementations must not extend Unicode property support to the remaining enumeration properties.</p>
+  <p>Implementations must support the following non-binary Unicode properties and their property aliases:</p>
+  <ul>
+    <li>`General_Category`</li>
+    <li>`Script`</li>
+    <li>`Script_Extensions`</li>
+  </ul>
+  <p>Additionally, implementations must support the following binary Unicode properties and their property aliases:</p>
+  <ul>
+    <li>`Alphabetic`</li>
+    <li>`Any`</li>
+    <li>`ASCII`</li>
+    <li>`ASCII_Hex_Digit`</li>
+    <li>`Assigned`</li>
+    <li>`Bidi_Control`</li>
+    <li>`Bidi_Mirrored`</li>
+    <li>`Case_Ignorable`</li>
+    <li>`Cased`</li>
+    <li>`Changes_When_Casefolded`</li>
+    <li>`Changes_When_Casemapped`</li>
+    <li>`Changes_When_Lowercased`</li>
+    <li>`Changes_When_NFKC_Casefolded`</li>
+    <li>`Changes_When_Titlecased`</li>
+    <li>`Changes_When_Uppercased`</li>
+    <li>`Composition_Exclusion`</li>
+    <li>`Dash`</li>
+    <li>`Default_Ignorable_Code_Point`</li>
+    <li>`Deprecated`</li>
+    <li>`Diacritic`</li>
+    <li>`Emoji`</li>
+    <li>`Emoji_Modifier`</li>
+    <li>`Emoji_Modifier_Base`</li>
+    <li>`Emoji_Presentation`</li>
+    <li>`Expands_On_NFC`</li>
+    <li>`Expands_On_NFD`</li>
+    <li>`Expands_On_NFKC`</li>
+    <li>`Expands_On_NFKD`</li>
+    <li>`Extender`</li>
+    <li>`FC_NFKC_Closure`</li>
+    <li>`Full_Composition_Exclusion`</li>
+    <li>`Grapheme_Base`</li>
+    <li>`Grapheme_Extend`</li>
+    <li>`Grapheme_Link`</li>
+    <li>`Hex_Digit`</li>
+    <li>`Hyphen`</li>
+    <li>`ID_Continue`</li>
+    <li>`ID_Start`</li>
+    <li>`Ideographic`</li>
+    <li>`IDS_Binary_Operator`</li>
+    <li>`IDS_Trinary_Operator`</li>
+    <li>`Join_Control`</li>
+    <li>`Logical_Order_Exception`</li>
+    <li>`Lowercase`</li>
+    <li>`Math`</li>
+    <li>`Noncharacter_Code_Point`</li>
+    <li>`Other_Alphabetic`</li>
+    <li>`Other_Default_Ignorable_Code_Point`</li>
+    <li>`Other_Grapheme_Extend`</li>
+    <li>`Other_ID_Continue`</li>
+    <li>`Other_ID_Start`</li>
+    <li>`Other_Lowercase`</li>
+    <li>`Other_Math`</li>
+    <li>`Other_Uppercase`</li>
+    <li>`Pattern_Syntax`</li>
+    <li>`Pattern_White_Space`</li>
+    <li>`Prepended_Concatenation_Mark`</li>
+    <li>`Quotation_Mark`</li>
+    <li>`Radical`</li>
+    <li>`Sentence_Terminal`</li>
+    <li>`Soft_Dotted`</li>
+    <li>`Terminal_Punctuation`</li>
+    <li>`Unified_Ideograph`</li>
+    <li>`Uppercase`</li>
+    <li>`Variation_Selector`</li>
+    <li>`White_Space`</li>
+    <li>`XID_Continue`</li>
+    <li>`XID_Start`</li>
+  </ul>
+  <emu-note>
+    <p>This is a superset of what <a href="http://unicode.org/reports/tr18/#RL1.2">UTS18 RL1.2</a> requires. To ensure interoperability, implementations must not extend Unicode property support to the remaining enumeration properties.</p>
+  </emu-note>
   <emu-note>
     <p>Only the canonical property names and property aliases listed in `PropertyAliases.txt` as well as the property names `Any`, `ASCII`, and `Assigned` must be recognized. For example, `Script_Extensions` and `scx` are valid, but `script_extensions` or `Scx` aren’t.</p>
   </emu-note>


### PR DESCRIPTION
Closes #18.

@allenwb This seems like an opportunity to fix #15 as well. Should I move this list to a separate section, titled “Supported Unicode properties”, and then refer to that section everytime the current text mentions “known” properties? I couldn’t find a similar example in the current spec so I’m open to suggestions here.